### PR TITLE
3.0.0 Release

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,21 +1,29 @@
+echo "build: Build started"
+
 Push-Location $PSScriptRoot
 
-if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
+if(Test-Path .\artifacts) {
+	echo "build: Cleaning .\artifacts"
+	Remove-Item .\artifacts -Force -Recurse
+}
 
-& dotnet restore
+& dotnet restore --no-cache
 
-$revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
+$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
 
-Push-Location src/Serilog.Enrichers.Thread
+echo "build: Version suffix is $suffix"
 
-& dotnet pack -c Release -o ..\..\.\artifacts --version-suffix=$revision
-if($LASTEXITCODE -ne 0) { exit 1 }    
+foreach ($src in ls src/*) {
+    Push-Location $src
 
-Pop-Location
-# Push-Location test/Serilog.Enrichers.Thread.Tests
+	echo "build: Packaging project in $src"
 
-# & dotnet test -c Release
-# if($LASTEXITCODE -ne 0) { exit 2 }
+    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix
+    if($LASTEXITCODE -ne 0) { exit 1 }    
 
-# Pop-Location
+    Pop-Location
+}
+
 Pop-Location

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
-# Serilog.Enrichers.Thread
+# Serilog.Enrichers.Thread [![Build status](https://ci.appveyor.com/api/projects/status/2vgxdy3swg6eaj3f?svg=true)](https://ci.appveyor.com/project/serilog/serilog-enrichers-thread) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Enrichers.Thread.svg?style=flat)](https://www.nuget.org/packages/Serilog.Enrichers.Thread/)
 
 Enrich Serilog events with properties from the current thread.
  
-[![Build status](https://ci.appveyor.com/api/projects/status/2vgxdy3swg6eaj3f?svg=true)](https://ci.appveyor.com/project/serilog/serilog-enrichers-thread) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Enrichers.Thread.svg?style=flat)](https://www.nuget.org/packages/Serilog.Enrichers.Thread/)
+### Getting started
 
-* [Documentation](https://github.com/serilog/serilog/wiki)
+Install the package from NuGet:
+
+```powershell
+Install-Package Serilog.Enrichers.Thread
+```
+
+In your logger configuration, apply `Enrich.WithThreadId()`:
+
+```csharp
+Log.Logger = new LoggerConfiguration()
+    .Enrich.WithThreadId()
+    .CreateLogger();
+```
+
 
 Copyright &copy; 2016 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 version: '{build}'
+skip_tags: true
 image: Visual Studio 2015
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0-preview2-002823'
+  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0-preview2-003121'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1
@@ -15,8 +16,14 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: ggZTqqV1z0xecDoQbeoy3A7xikShCt9FWZIGp95dG9Fo0p5RAT9oGU0ZekHfUIwk
+    secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x
   skip_symbols: true
   on:
-    branch: /^(dev|master)$/
-
+    branch: /^(master|dev)$/
+- provider: GitHub
+  auth_token:
+    secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
+  artifact: /Serilog.*\.nupkg/
+  tag: v$(appveyor_build_version)
+  on:
+    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x
+    secure: ggZTqqV1z0xecDoQbeoy3A7xikShCt9FWZIGp95dG9Fo0p5RAT9oGU0ZekHfUIwk
   skip_symbols: true
   on:
     branch: /^(dev|master)$/

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadIdEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadIdEnricher.cs
@@ -15,11 +15,12 @@
 using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
+using System;
 
 namespace Serilog.Enrichers
 {
     /// <summary>
-    /// Enriches log events with a ThreadId property containing the current <see cref="Thread.ManagedThreadId"/>.
+    /// Enriches log events with a ThreadId property containing the <see cref="Environment.CurrentManagedThreadId"/>.
     /// </summary>
     public class ThreadIdEnricher : ILogEventEnricher
     {
@@ -35,7 +36,7 @@ namespace Serilog.Enrichers
         /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadIdPropertyName, new ScalarValue(Thread.CurrentThread.ManagedThreadId)));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadIdPropertyName, new ScalarValue(Environment.CurrentManagedThreadId)));
         }
     }
 }

--- a/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
@@ -21,13 +21,13 @@ using Serilog.Enrichers;
 namespace Serilog
 {
     /// <summary>
-    /// Extends <see cref="LoggerConfiguration"/> to add enrichers for <see cref="Thread"/>.
+    /// Extends <see cref="LoggerConfiguration"/> to add enrichers for <see cref="Environment.CurrentManagedThreadId"/>.
     /// capabilities.
     /// </summary>
     public static class ThreadLoggerConfigurationExtensions
     {
         /// <summary>
-        /// Enrich log events with a ThreadId property containing the current <see cref="Thread.ManagedThreadId"/>.
+        /// Enrich log events with a ThreadId property containing the <see cref="Environment.CurrentManagedThreadId"/>.
         /// </summary>
         /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
         /// <returns>Configuration object allowing method chaining.</returns>

--- a/src/Serilog.Enrichers.Thread/project.json
+++ b/src/Serilog.Enrichers.Thread/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.0.1-*",
+  "version": "3.0.0-*",
   "description": "Enrich Serilog events with properties from the current thread.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Enrichers.Thread/project.json
+++ b/src/Serilog.Enrichers.Thread/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.0.0-rc-*",
+  "version": "2.0.1-*",
   "description": "Enrich Serilog events with properties from the current thread.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-enricher-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.0.0-rc-577"
+    "Serilog": "2.0.0"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk",
@@ -19,9 +19,8 @@
   "frameworks": {
     "net4.5": {
     },
-    "netstandard1.3": {
+    "netstandard1.0": {
       "dependencies": {
-        "System.Threading.Thread": "4.0.0-rc2-24027"
       }
     }
   }


### PR DESCRIPTION
 * #6 - UWP and netstandard1.0 support

Note, removal of the _System.Threading.Thread_ dependency may break packages that make use of it as a transient dependency. Bumping major version to reflect that.