### PR TITLE
ThreadName Enricher added for Net45 and Standard2.0

### DIFF
--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+#if THREAD_NAME
 using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
 
 namespace Serilog.Enrichers 
 {
-#if NET45 || NETSTANDARD2_0
+
     /// <summary>
     /// Enriches log events with a ThreadName property containing the 
     /// </summary>
@@ -44,5 +44,5 @@ namespace Serilog.Enrichers
             }
         }
     }
-#endif
 }
+#endif

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -17,19 +17,18 @@ using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
 
-namespace Serilog.Enrichers {
+namespace Serilog.Enrichers 
+{
 #if NET45 || NETSTANDARD2_0
     /// <summary>
     /// Enriches log events with a ThreadName property containing the 
     /// </summary>
     public class ThreadNameEnricher : ILogEventEnricher 
     {
-
         /// <summary>
         /// The property name added to enriched log events.
         /// </summary>
         public const string ThreadNamePropertyName = "ThreadName";
-
 
         /// <summary>
         /// Enrich the log event.
@@ -41,7 +40,7 @@ namespace Serilog.Enrichers {
             var threadName = Thread.CurrentThread.Name;
             if (threadName != null) 
             {
-                logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadNamePropertyName, new ScalarValue(Thread.CurrentThread.Name)));
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadNamePropertyName, new ScalarValue(threadName)));
             }
         }
     }

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -12,31 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
-using System;
 
-namespace Serilog.Enrichers
-{
+namespace Serilog.Enrichers {
+#if NET45 || NETSTANDARD2_0
     /// <summary>
-    /// Enriches log events with a ThreadId property containing the <see cref="Environment.CurrentManagedThreadId"/>.
+    /// Enriches log events with a ThreadName property containing the 
     /// </summary>
-    public class ThreadIdEnricher : ILogEventEnricher
+    public class ThreadNameEnricher : ILogEventEnricher 
     {
+
         /// <summary>
         /// The property name added to enriched log events.
         /// </summary>
-        public const string ThreadIdPropertyName = "ThreadId";
+        public const string ThreadNamePropertyName = "ThreadName";
+
 
         /// <summary>
         /// Enrich the log event.
         /// </summary>
         /// <param name="logEvent">The log event to enrich.</param>
         /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory) 
         {
-            logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadIdPropertyName, new ScalarValue(Environment.CurrentManagedThreadId)));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadNamePropertyName, new ScalarValue(Thread.CurrentThread.Name)));
         }
     }
+#endif
 }

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -38,7 +38,11 @@ namespace Serilog.Enrichers {
         /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory) 
         {
-            logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadNamePropertyName, new ScalarValue(Thread.CurrentThread.Name)));
+            var threadName = Thread.CurrentThread.Name;
+            if (threadName != null) 
+            {
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(ThreadNamePropertyName, new ScalarValue(Thread.CurrentThread.Name)));
+            }
         }
     }
 #endif

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -28,4 +28,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DefineConstants>$(DefineConstants);THREAD_NAME</DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);THREAD_NAME</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
@@ -39,7 +39,7 @@ namespace Serilog
             return enrichmentConfiguration.With<ThreadIdEnricher>();
         }
 
-#if NET45 || NETSTANDARD2_0
+#if THREAD_NAME
         /// <summary>
         /// Enrich log events with a ThreadName property containing the <see cref="Thread.CurrentThread"/> <see cref="Thread.Name"/>.
         /// </summary>

--- a/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2016 Serilog Contributors
+﻿// Copyright 2013-2019 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,5 +38,19 @@ namespace Serilog
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
             return enrichmentConfiguration.With<ThreadIdEnricher>();
         }
+
+#if NET45 || NETSTANDARD2_0
+        /// <summary>
+        /// Enrich log events with a ThreadName property containing the <see cref="Thread.CurrentThread"/> <see cref="Thread.Name"/>.
+        /// </summary>
+        /// <param name="enrichmentConfiguration"></param>
+        /// <returns></returns>
+        public static LoggerConfiguration WithThreadName(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        {
+            if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
+            return enrichmentConfiguration.With<ThreadNameEnricher>();
+        }
+#endif
     }
 }


### PR DESCRIPTION
ThreadName Enricher added for Net45 and NetStandard2.0.
Unfortunately Thread is not available in NetStandard1.0.

Changed the copyright statement to include 2019.

Question before merge:
At the moment in the output of a non set thread name will be `ThreadName=null`. I could think of an overload for the `EnrichWithThreadName(string nameIfNotSet)` method to specify a default value instead of `null`. Thoughts?