### PR TITLE
Bump Serilog version dependency to support Unity and .netstandard 2.0+

### DIFF
--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Same problem as this

https://github.com/serilog/serilog-extensions-logging/pull/188