### PR TITLE
Updates for Serilog 4

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -20,7 +20,7 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix
+    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix -p:ContinuousIntegrationBuild=true
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Enrich Serilog events with properties from the current thread.
 
-`WithThreadName()` is only supported in .NetStandard 2.0 and .NetFramework 4.5.
- 
 ### Getting started
 
 Install the package from NuGet:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ build_script:
 test: off
 artifacts:
 - path: artifacts/Serilog.*.nupkg
+- path: artifacts/Serilog.*.snupkg
 deploy:
 - provider: NuGet
   api_key:
@@ -17,7 +18,9 @@ deploy:
 - provider: GitHub
   auth_token:
     secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
-  artifact: /Serilog.*\.nupkg/
+  artifacts:
+    /Serilog.*\.nupkg/
+    /Serilog.*\.snupkg/
   tag: v$(appveyor_build_version)
   on:
     branch: master

--- a/global.json
+++ b/global.json
@@ -1,1 +1,0 @@
-{"projects":["src","test"]}

--- a/serilog-enrichers-thread.sln
+++ b/serilog-enrichers-thread.sln
@@ -1,14 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34928.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{037440DE-440B-4129-9F7A-09B42D00397E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{E9D1B5E1-DEB9-4A04-8BAB-24EC7240ADAF}"
 	ProjectSection(SolutionItems) = preProject
 		Build.ps1 = Build.ps1
-		global.json = global.json
 		README.md = README.md
 		assets\Serilog.snk = assets\Serilog.snk
 	EndProjectSection

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadIdEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadIdEnricher.cs
@@ -21,12 +21,12 @@ namespace Serilog.Enrichers
     /// <summary>
     /// Enriches log events with a ThreadId property containing the <see cref="Environment.CurrentManagedThreadId"/>.
     /// </summary>
-    public class ThreadIdEnricher : ILogEventEnricher
+    sealed class ThreadIdEnricher : ILogEventEnricher
     {
         /// <summary>
         /// The property name added to enriched log events.
         /// </summary>
-        public const string ThreadIdPropertyName = "ThreadId";
+        const string ThreadIdPropertyName = "ThreadId";
 
         /// <summary>
         /// The cached last created "ThreadId" property with some thread id. It is likely to be reused frequently so avoiding heap allocations.

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadIdEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadIdEnricher.cs
@@ -43,7 +43,7 @@ namespace Serilog.Enrichers
             var threadId = Environment.CurrentManagedThreadId;
 
             var last = _lastValue;
-            if (last == null || (int)((ScalarValue)last.Value).Value != threadId)
+            if (last is null || (int)((ScalarValue)last.Value).Value! != threadId)
                 // no need to synchronize threads on write - just some of them will win
                 _lastValue = last = new LogEventProperty(ThreadIdPropertyName, new ScalarValue(threadId));
 

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -41,10 +41,10 @@ namespace Serilog.Enrichers
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory) 
         {
             var threadName = Thread.CurrentThread.Name;
-            if (threadName != null) 
+            if (threadName is not null) 
             {
                 var last = _lastValue;
-                if (last == null || (string)((ScalarValue)last.Value).Value != threadName)
+                if (last is null || (string)((ScalarValue)last.Value).Value! != threadName)
                     // no need to synchronize threads on write - just some of them will win
                     _lastValue = last = new LogEventProperty(ThreadNamePropertyName, new ScalarValue(threadName));
 

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -21,12 +21,12 @@ namespace Serilog.Enrichers
     /// <summary>
     /// Enriches log events with a ThreadName property containing the <see cref="Thread.CurrentThread"/> <see cref="Thread.Name"/>.
     /// </summary>
-    public class ThreadNameEnricher : ILogEventEnricher 
+    sealed class ThreadNameEnricher : ILogEventEnricher 
     {
         /// <summary>
         /// The property name added to enriched log events.
         /// </summary>
-        public const string ThreadNamePropertyName = "ThreadName";
+        const string ThreadNamePropertyName = "ThreadName";
 
         /// <summary>
         /// The cached last created "ThreadName" property with some thread name. It is likely to be reused frequently so avoiding heap allocations.

--- a/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
+++ b/src/Serilog.Enrichers.Thread/Enrichers/ThreadNameEnricher.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if THREAD_NAME
 using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
@@ -54,4 +53,3 @@ namespace Serilog.Enrichers
         }
     }
 }
-#endif

--- a/src/Serilog.Enrichers.Thread/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Enrichers.Thread/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-using System;
-using System.Reflection;
-
-[assembly: AssemblyVersion("2.0.0.0")]
-
-[assembly: CLSCompliant(true)]

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Enrich Serilog events with properties from the current thread.</Description>
     <VersionPrefix>4.0.0</VersionPrefix>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <Authors>Serilog Contributors</Authors>
     <!-- .NET Framework version targeting is frozen at these two TFMs. -->
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>
@@ -22,7 +23,6 @@
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Enrich Serilog events with properties from the current thread.</Description>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <!-- .NET Framework version targeting is frozen at these two TFMs. -->
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -4,7 +4,12 @@
     <Description>Enrich Serilog events with properties from the current thread.</Description>
     <VersionPrefix>3.2.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <!-- .NET Framework version targeting is frozen at these two TFMs. -->
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>
+    <!-- Policy is to trim TFM-specific builds to `netstandard2.0`, `net6.0`,
+         all active LTS versions, and optionally the latest RTM version, when releasing new
+         major Serilog versions. -->
+    <TargetFrameworks>$(TargetFrameworks);net8.0;net6.0;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Enrichers.Thread</AssemblyName>
@@ -25,24 +30,11 @@
     <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\assets\serilog-enricher-nuget.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);THREAD_NAME</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);THREAD_NAME</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -21,6 +21,7 @@
     <PackageIcon>serilog-enricher-nuget.png</PackageIcon>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -35,6 +36,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+    <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
+++ b/src/Serilog.Enrichers.Thread/Serilog.Enrichers.Thread.csproj
@@ -23,6 +23,10 @@
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Thread/ThreadLoggerConfigurationExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 using System;
 using System.Threading;
 using Serilog.Configuration;
@@ -39,7 +38,6 @@ namespace Serilog
             return enrichmentConfiguration.With<ThreadIdEnricher>();
         }
 
-#if THREAD_NAME
         /// <summary>
         /// Enrich log events with a ThreadName property containing the <see cref="Thread.CurrentThread"/> <see cref="Thread.Name"/>.
         /// </summary>
@@ -52,6 +50,5 @@ namespace Serilog
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
             return enrichmentConfiguration.With<ThreadNameEnricher>();
         }
-#endif
     }
 }


### PR DESCRIPTION
Update to Serilog 4, update explicit TFMs to match, internalize the enricher classes as described for the Environment enricher in https://github.com/serilog/serilog-enrichers-environment/pull/63